### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/make_cited_reference_df.R
+++ b/make_cited_reference_df.R
@@ -48,7 +48,7 @@ make_cited_reference_df <- function(dictionnary) {
     if ( length(startpos) !=0 ){
     simple_doi <- substr(doi, startpos,nchar(doi))
     doi <- substr(doi, startpos,nchar(doi))
-    doi <- paste('<a href="http://dx.doi.org/',doi,'">',doi,'</a>', sep = "")
+    doi <- paste('<a href="https://doi.org/',doi,'">',doi,'</a>', sep = "")
     } else simple_doi <- NA
     splitted_cited_reference_df[current_row,2:8] <- list(
       author,

--- a/make_scopus_cited_reference_df.R
+++ b/make_scopus_cited_reference_df.R
@@ -46,7 +46,7 @@ make_scopus_cited_reference_df <- function(dictionnary) {
     if ( length(startpos) !=0 ){
     simple_doi <- substr(doi, startpos,nchar(doi))
     doi <- substr(doi, startpos,nchar(doi))
-    doi <- paste('<a href="http://dx.doi.org/',doi,'">',doi,'</a>', sep = "")
+    doi <- paste('<a href="https://doi.org/',doi,'">',doi,'</a>', sep = "")
     } else simple_doi <- NA
     splitted_cited_reference_df[current_row,2:8] <- list(
       author,


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing the code that generates new DOI links.

Cheers :-)